### PR TITLE
Fix link typo

### DIFF
--- a/_site/docs/index.html
+++ b/_site/docs/index.html
@@ -132,7 +132,7 @@ ul.task-list li input[type="checkbox"] {
 <p>Here is a list of links to all my recipes:</p>
 <ul>
 <li><a href="brownies.html">Fudgy Brownies</a></li>
-<li><a href="choc_chip_cookies.html">Chocolate Chip Cookes</a></li>
+<li><a href="choc_chip_cookies.html">Chocolate Chip Cookies</a></li>
 <li><a href="vanilla_simple_syrup.html">Vanilla Simple Syrup</a></li>
 <li><a href="dalgona_coffee.html">Dalgona Coffee (South Asian Whipped Coffee)</a></li>
 <li><a href="mug_brownie.html">5-minute Microwave Mug Brownie</a></li>

--- a/_site/index.html
+++ b/_site/index.html
@@ -132,7 +132,7 @@ ul.task-list li input[type="checkbox"] {
 <p>Here is a list of links to all my recipes:</p>
 <ul>
 <li><a href="brownies.html">Fudgy Brownies</a></li>
-<li><a href="choc_chip_cookies.html">Chocolate Chip Cookes</a></li>
+<li><a href="choc_chip_cookies.html">Chocolate Chip Cookies</a></li>
 <li><a href="vanilla_simple_syrup.html">Vanilla Simple Syrup</a></li>
 <li><a href="dalgona_coffee.html">Dalgona Coffee (South Asian Whipped Coffee)</a></li>
 <li><a href="mug_brownie.html">5-minute Microwave Mug Brownie</a></li>

--- a/_site/search.json
+++ b/_site/search.json
@@ -4,7 +4,7 @@
     "href": "index.html",
     "title": "marium-bakes",
     "section": "",
-    "text": "Hi! I am a self-proclaimed baking enthusiast who sometimes dabbles into cooking!\nSome of my recipes are from the internet and others have been passed down from family and friends!\nHere is a list of links to all my recipes:\n\nFudgy Brownies\nChocolate Chip Cookes\nVanilla Simple Syrup\nDalgona Coffee (South Asian Whipped Coffee)\n5-minute Microwave Mug Brownie\nChocolate Fudge"
+    "text": "Hi! I am a self-proclaimed baking enthusiast who sometimes dabbles into cooking!\nSome of my recipes are from the internet and others have been passed down from family and friends!\nHere is a list of links to all my recipes:\n\nFudgy Brownies\nChocolate Chip Cookies\nVanilla Simple Syrup\nDalgona Coffee (South Asian Whipped Coffee)\n5-minute Microwave Mug Brownie\nChocolate Fudge"
   },
   {
     "objectID": "mug_brownie.html",
@@ -53,7 +53,7 @@
     "href": "docs/index.html",
     "title": "marium-bakes",
     "section": "",
-    "text": "Hi! I am a self-proclaimed baking enthusiast who sometimes dabbles into cooking!\nSome of my recipes are from the internet and others have been passed down from family and friends!\nHere is a list of links to all my recipes:\n\nFudgy Brownies\nChocolate Chip Cookes\nVanilla Simple Syrup\nDalgona Coffee (South Asian Whipped Coffee)\n5-minute Microwave Mug Brownie\nChocolate Fudge"
+    "text": "Hi! I am a self-proclaimed baking enthusiast who sometimes dabbles into cooking!\nSome of my recipes are from the internet and others have been passed down from family and friends!\nHere is a list of links to all my recipes:\n\nFudgy Brownies\nChocolate Chip Cookies\nVanilla Simple Syrup\nDalgona Coffee (South Asian Whipped Coffee)\n5-minute Microwave Mug Brownie\nChocolate Fudge"
   },
   {
     "objectID": "vanilla_simple_syrup.html",

--- a/docs/index.html
+++ b/docs/index.html
@@ -89,7 +89,7 @@ ul.task-list li input[type="checkbox"] {
 <h2 class="anchored" data-anchor-id="desserts">Desserts</h2>
 <ul>
 <li><a href="desserts/brownies.html">Fudgy Brownies</a></li>
-<li><a href="desserts/choc_chip_cookies.html">Chocolate Chip Cookes</a></li>
+<li><a href="desserts/choc_chip_cookies.html">Chocolate Chip Cookies</a></li>
 <li><a href="desserts/mug_brownie.html">5-minute Microwave Mug Brownie</a></li>
 <li><a href="desserts/fudge.html">Chocolate Fudge</a></li>
 <li><a href="https://sallysbakingaddiction.com/best-banana-bread-recipe/">Banana Bread</a></li>

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -9,7 +9,7 @@ Some of my recipes are from the internet and others have been passed down from f
 Here is a list of links to all my recipes:
 
 * [Fudgy Brownies](brownies.html)
-* [Chocolate Chip Cookes](choc_chip_cookies.html)
+* [Chocolate Chip Cookies](choc_chip_cookies.html)
 * [Vanilla Simple Syrup](vanilla_simple_syrup.html)
 * [Dalgona Coffee (South Asian Whipped Coffee)](dalgona_coffee.html)
 * [5-minute Microwave Mug Brownie](mug_brownie.html)

--- a/docs/search.json
+++ b/docs/search.json
@@ -102,7 +102,7 @@
     "href": "index.html#desserts",
     "title": "marium bakes (and cooks)",
     "section": "Desserts",
-    "text": "Desserts\n\nFudgy Brownies\nChocolate Chip Cookes\n5-minute Microwave Mug Brownie\nChocolate Fudge\nBanana Bread\nXander’s Dark Chocolate Tart but instead of the berries, top with a homemade Caramel Sauce"
+    "text": "Desserts\n\nFudgy Brownies\nChocolate Chip Cookies\n5-minute Microwave Mug Brownie\nChocolate Fudge\nBanana Bread\nXander’s Dark Chocolate Tart but instead of the berries, top with a homemade Caramel Sauce"
   },
   {
     "objectID": "index.html#coffee-its-assecories",

--- a/index.qmd
+++ b/index.qmd
@@ -6,7 +6,7 @@ Some of my recipes are from the internet; others have been passed down from fami
 ## Desserts
 
 * [Fudgy Brownies](desserts/brownies.html)
-* [Chocolate Chip Cookes](desserts/choc_chip_cookies.html)
+* [Chocolate Chip Cookies](desserts/choc_chip_cookies.html)
 * [5-minute Microwave Mug Brownie](desserts/mug_brownie.html)
 * [Chocolate Fudge](desserts/fudge.html)
 * [Banana Bread](https://sallysbakingaddiction.com/best-banana-bread-recipe/)


### PR DESCRIPTION
## Summary
- correct typo 'Chocolate Chip Cookes' to 'Chocolate Chip Cookies' in the landing page
- update generated HTML and search metadata accordingly

## Testing
- `grep -n "Cookes" -R`

------
https://chatgpt.com/codex/tasks/task_e_6868c8ac56f083249e410085b16d5552